### PR TITLE
Don't fetch the pools-v2.json file on a signet network

### DIFF
--- a/backend/src/tasks/pools-updater.ts
+++ b/backend/src/tasks/pools-updater.ts
@@ -31,7 +31,7 @@ class PoolsUpdater {
   }
 
   public async updatePoolsJson(): Promise<void> {
-    if (['mainnet', 'testnet', 'signet'].includes(config.MEMPOOL.NETWORK) === false ||
+    if (['mainnet', 'testnet'].includes(config.MEMPOOL.NETWORK) === false ||
       config.MEMPOOL.ENABLED === false
     ) {
       return;


### PR DESCRIPTION
This function is making my life difficult. The signet-playground mempool-api container doesn't work on one of my computers because it is unable to fetch that pools-v2.json file from GitHub.

But there are no pools on a signet network, so I don't see why fetching this file shouldn't be skipped anyway when we're on signet.