### PR TITLE
Minor UI consistency improvements

### DIFF
--- a/frontend/proxy.conf.js
+++ b/frontend/proxy.conf.js
@@ -26,14 +26,14 @@ PROXY_CONFIG = [
         '!/liquidtestnet', '!/liquidtestnet/**', '!/liquidtestnet/',
         '/testnet/api/**', '/signet/api/**', '/testnet4/api/**'
         ],
-        target: "https://mempool.space",
+        target: "https://mempool.guide",
         ws: true,
         secure: false,
         changeOrigin: true
     },
     {
         context: ['/api/v1/ws'],
-        target: "https://mempool.space",
+        target: "https://mempool.guide",
         ws: true,
         secure: false,
         changeOrigin: true,
@@ -57,7 +57,7 @@ PROXY_CONFIG = [
     },
     {
       context: ['/resources/mining-pools/**'],
-      target: "https://mempool.space",
+    target: "https://mempool.guide",
       secure: false,
       changeOrigin: true
   }
@@ -75,7 +75,7 @@ if (configContent && configContent.BASE_MODULE == "liquid") {
 } else {
     PROXY_CONFIG.push({
         context: ['/resources/assets.json', '/resources/assets.minimal.json', '/resources/worldmap.json'],
-        target: "https://mempool.space",
+        target: "https://mempool.guide",
         secure: false,
         changeOrigin: true,
     });

--- a/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
+++ b/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
@@ -1,11 +1,10 @@
-import { ChangeDetectionStrategy, Component, Input, NgZone, OnInit, HostBinding } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, NgZone, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map, shareReplay, tap } from 'rxjs/operators';
-import { EChartsOption, PieSeriesOption } from '../../graphs/echarts';
-import { BitnodesService, KnotsNodeStats, KnotsNodeResponse } from '../../services/bitnodes.service';
-import { originalChartColors as chartColors } from '../../app.constants';
-import { download } from '../../shared/graphs.utils';
+import { shareReplay, tap } from 'rxjs/operators';
+import { EChartsOption } from '../../graphs/echarts';
+import { BitnodesService, KnotsNodeResponse, KnotsNodeStats } from '../../services/bitnodes.service';
 import { isMobile } from '../../shared/common.utils';
+import { download } from '../../shared/graphs.utils';
 
 @Component({
   selector: 'app-knots-nodes-chart',
@@ -196,7 +195,8 @@ export class KnotsNodesChartComponent implements OnInit {
           trigger: 'item',
           textStyle: {
             align: 'left',
-          }
+          },
+          backgroundColor: 'rgba(17, 19, 31, 1)',
         },
         series: [
           {

--- a/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
+++ b/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
@@ -190,7 +190,7 @@ export class KnotsNodesChartComponent implements OnInit {
       }
 
       this.chartOptions = {
-        animation: false,
+        animation: true,
         color: ['#1E88E5', '#8E24AA'],
         tooltip: {
           trigger: 'item',
@@ -222,6 +222,8 @@ export class KnotsNodesChartComponent implements OnInit {
               borderColor: '#000',
             },
             emphasis: {
+              scale: true,
+              scaleSize: 10,
               itemStyle: {
                 shadowBlur: 40,
                 shadowColor: 'rgba(0, 0, 0, 0.75)',

--- a/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
+++ b/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
@@ -1,10 +1,11 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input, NgZone, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, NgZone, OnInit, HostBinding } from '@angular/core';
 import { Observable } from 'rxjs';
-import { shareReplay, tap } from 'rxjs/operators';
-import { EChartsOption } from '../../graphs/echarts';
-import { BitnodesService, KnotsNodeResponse, KnotsNodeStats } from '../../services/bitnodes.service';
-import { isMobile } from '../../shared/common.utils';
+import { map, shareReplay, tap } from 'rxjs/operators';
+import { EChartsOption, PieSeriesOption } from '../../graphs/echarts';
+import { BitnodesService, KnotsNodeStats, KnotsNodeResponse } from '../../services/bitnodes.service';
+import { originalChartColors as chartColors } from '../../app.constants';
 import { download } from '../../shared/graphs.utils';
+import { isMobile } from '../../shared/common.utils';
 
 @Component({
   selector: 'app-knots-nodes-chart',

--- a/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
+++ b/frontend/src/app/components/knots-nodes-chart/knots-nodes-chart.component.ts
@@ -208,6 +208,7 @@ export class KnotsNodesChartComponent implements OnInit {
             radius: pieSize,
             data: pieData,
             labelLine: {
+              length2: 25,
               lineStyle: {
                 width: 2,
               },

--- a/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
+++ b/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectionStrategy, Component, Input, NgZone, OnInit, HostBinding } from '@angular/core';
+import { ChangeDetectionStrategy, Component, HostBinding, Input, NgZone, OnInit } from '@angular/core';
 import { Observable } from 'rxjs';
-import { map, shareReplay, tap } from 'rxjs/operators';
-import { EChartsOption, PieSeriesOption } from '../../graphs/echarts';
-import { OceanService, OceanTemplateStats, OceanHashrateData } from '../../services/ocean.service';
+import { shareReplay, tap } from 'rxjs/operators';
 import { originalChartColors as chartColors } from '../../app.constants';
-import { download } from '../../shared/graphs.utils';
+import { EChartsOption, PieSeriesOption } from '../../graphs/echarts';
+import { OceanHashrateData, OceanService, OceanTemplateStats } from '../../services/ocean.service';
 import { isMobile } from '../../shared/common.utils';
+import { download } from '../../shared/graphs.utils';
 
 @Component({
   selector: 'app-ocean-hashrate-chart',
@@ -132,7 +132,7 @@ export class OceanHashrateChartComponent implements OnInit {
         tooltip: {
           trigger: 'item',
           textStyle: {
-            color: '#b1b1b1',
+            align: 'left',
           },
           backgroundColor: 'rgba(17, 19, 31, 1)',
           borderRadius: 4,

--- a/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
+++ b/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
@@ -156,11 +156,10 @@ export class OceanHashrateChartComponent implements OnInit {
             label: {
               show: true, // Always show labels
               position: 'outside',
-              alignTo: 'edge',
               minMargin: 5,
               edgeDistance: edgeDistance,
               lineHeight: 15,
-              fontSize: this.widget ? 10 : 12,
+              fontSize: 14,
               fontWeight: 'normal',
               formatter: (data: any) => {
                 const percentage = data.data?.percentage || data.percentage || 0;
@@ -175,15 +174,11 @@ export class OceanHashrateChartComponent implements OnInit {
                 }
               }
             },
-            labelLine: {
-              show: true, // Always show label lines
-              length: this.widget ? 10 : 20,
-              length2: this.widget ? 3 : 5,
-              maxSurfaceAngle: 80,
+           labelLine: {
+              length2: 25,
               lineStyle: {
-                color: '#666666',
-                width: 1
-              }
+                width: 2,
+              },
             },
             emphasis: {
               scale: true,
@@ -192,6 +187,11 @@ export class OceanHashrateChartComponent implements OnInit {
                 shadowBlur: 10,
                 shadowOffsetX: 0,
                 shadowColor: 'rgba(0, 0, 0, 0.5)'
+              },
+              labelLine: {
+                lineStyle: {
+                  width: 3,
+                }
               }
             },
             itemStyle: {

--- a/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
+++ b/frontend/src/app/components/ocean-hashrate-chart/ocean-hashrate-chart.component.ts
@@ -1,11 +1,11 @@
-import { ChangeDetectionStrategy, Component, HostBinding, Input, NgZone, OnInit } from '@angular/core';
+import { ChangeDetectionStrategy, Component, Input, NgZone, OnInit, HostBinding } from '@angular/core';
 import { Observable } from 'rxjs';
-import { shareReplay, tap } from 'rxjs/operators';
-import { originalChartColors as chartColors } from '../../app.constants';
+import { map, shareReplay, tap } from 'rxjs/operators';
 import { EChartsOption, PieSeriesOption } from '../../graphs/echarts';
-import { OceanHashrateData, OceanService, OceanTemplateStats } from '../../services/ocean.service';
-import { isMobile } from '../../shared/common.utils';
+import { OceanService, OceanTemplateStats, OceanHashrateData } from '../../services/ocean.service';
+import { originalChartColors as chartColors } from '../../app.constants';
 import { download } from '../../shared/graphs.utils';
+import { isMobile } from '../../shared/common.utils';
 
 @Component({
   selector: 'app-ocean-hashrate-chart',

--- a/frontend/src/app/dashboard/dashboard.component.html
+++ b/frontend/src/app/dashboard/dashboard.component.html
@@ -76,7 +76,7 @@
       </div>
     </div>
     
-    <div class="knots-progress-fullwidth-container">
+    <div class="col knots-progress-fullwidth-container">
       <div class="knots-progress-wrapper">
         <div class="progress-header">
           <h6 class="progress-title" i18n="knots.network-distribution">BIP 110 Network Distribution</h6>


### PR DESCRIPTION
## Description

Fixed a few UI styling inconsistencies 

Before
<img width="507" height="259" alt="image" src="https://github.com/user-attachments/assets/667388da-d4e1-4897-8612-bce3051b71d3" /> 
<img width="334" height="243" alt="image" src="https://github.com/user-attachments/assets/e1a67969-4d08-4c51-b3bf-9dd3fc4ae36f" />

After
<img width="355" height="276" alt="image" src="https://github.com/user-attachments/assets/bd78a704-ab35-4727-b63e-280a2a59efea" /> 
<img width="370" height="248" alt="image" src="https://github.com/user-attachments/assets/490c3cbe-5f3c-43e4-bf74-ca083d5ce558" />


Also changed the local dev proxy address to point to `mempool.guide` in order to load ocean/knots data.

## Changes

- vertical padding between BIP-110 panel and lower panels is now the same as every where else.
- enabled animation of knots pie chart on hover to match the ocean chart hover interaction.
- made charts label lines length consistent across charts.
- made chart tooltips style consistent across both charts (ocean/knots):
  - the knots nodes chart tooltip background colour was white making it hard to read the text
  - the ocean chart tooltip text is now left aligned and uses default text colour just like the other chart.
- changed the proxy target url to point to .guide so that ocean/knots data loads.