### PR TITLE
Replace bitnodes.io (down) with Luke Dashjr API for Knots/BIP110 stats

### DIFF
--- a/backend/src/api/bitcoin/bitcoin.routes.ts
+++ b/backend/src/api/bitcoin/bitcoin.routes.ts
@@ -269,36 +269,33 @@ class BitcoinRoutes {
         return;
       }
 
-      logger.debug('Fetching fresh Bitcoin Knots nodes stats from Bitnodes API');
-      const response = await axios.get('https://bitnodes.io/api/v1/snapshots/latest', {
-        timeout: 10000,
+      logger.debug('Fetching fresh Bitcoin Knots nodes stats from Luke Dashjr API');
+      const response = await axios.get('https://luke.dashjr.org/programs/bitcoin/files/charts/data/uainfo.json', {
+        timeout: 15000,
         headers: {
           'User-Agent': 'Mempool.space/1.0'
         }
       });
 
-      const snapshot = response.data;
-      const totalBitcoinNodes = snapshot.total_nodes;
+      const uainfo = response.data;
+      let totalBitcoinNodes = 0;
       let totalKnotsNodesClearnet = 0;
       let torNodeCount = 0;
-      let fullCount = 0;
       let bipcount = 0;
 
-      Object.entries(snapshot.nodes).forEach(([address, nodeData]: [string, any]) => {
-        const userAgent = nodeData[1];
-        if (userAgent && userAgent.toLowerCase().includes('bip110')){
-          bipcount++;
+      Object.entries(uainfo).forEach(([ua, data]: [string, any]) => {
+        const nodeCount = (data.listening || 0) + (data.est_unreachable || 0);
+        totalBitcoinNodes += nodeCount;
+        const uaLower = ua.toLowerCase();
+        if (uaLower.includes('bip110')) {
+          bipcount += nodeCount;
         }
-        if (userAgent && userAgent.toLowerCase().includes('knots')) {
-          if (address.includes('.onion')) {
-            torNodeCount++;
-          } else {
-            totalKnotsNodesClearnet++;
-          }
+        if (uaLower.includes('knots')) {
+          totalKnotsNodesClearnet += nodeCount;
         }
       });
 
-      fullCount = torNodeCount + totalKnotsNodesClearnet;
+      const fullCount = totalKnotsNodesClearnet + torNodeCount;
       const knotsPercentageOfTotal = totalBitcoinNodes > 0 ? (fullCount / totalBitcoinNodes) * 100 : 0;
 
       const result = {

--- a/frontend/src/app/dashboard/dashboard.component.ts
+++ b/frontend/src/app/dashboard/dashboard.component.ts
@@ -402,7 +402,7 @@ export class DashboardComponent implements OnInit, OnDestroy, AfterViewInit {
       this.knotsPercentage = knotsData.totals.percentageOfTotal;
       this.totalKnotsNodes = knotsData.totals.totalNodes;
       this.totalBitcoinNodes = Math.round(this.totalKnotsNodes / (this.knotsPercentage / 100));
-      this.bipPercentage = (knotsData.totals.bipCount * 100) / knotsData.totals.totalBitcoinNodes;
+      this.bipPercentage = knotsData.totals.totalBitcoinNodes > 0 ? (knotsData.totals.bipCount * 100) / knotsData.totals.totalBitcoinNodes : 0;
     });
   }
 


### PR DESCRIPTION
## Problem

`bitnodes.io` stopped resolving (NXDOMAIN) — its API endpoint `https://bitnodes.io/api/v1/snapshots/latest` is unreachable. This broke two things on the dashboard:

- **Knots nodes** showing **0** (no data returned)
- **BIP110 %** showing **NaN%** (division by zero when `totalBitcoinNodes = 0`)

## Solution

Replace the data source with **Luke Dashjr's `uainfo.json`** (`https://luke.dashjr.org/programs/bitcoin/files/charts/data/uainfo.json`), which provides equivalent information: per-user-agent node counts with `listening` and `est_unreachable` fields.

The backend iterates over user agent strings (the JSON keys) and sums node counts for those containing `knots` or `bip110`, the same logic as before.

### Example data from Luke's API:
```json
{
  "/Satoshi:29.3.0/Knots:20260210+bip110-v0.4.1/UASF-BIP110:0.4/": {
    "listening": 180,
    "est_unreachable": 3295
  },
  ...
}
```

## Changes

- **`backend/src/api/bitcoin/bitcoin.routes.ts`** — switch API source and update parsing logic
- **`frontend/src/app/dashboard/dashboard.component.ts`** — guard `bipPercentage` against division by zero (defensive fix)

## Known limitation

Luke's API does not provide per-node connection info, so **Tor vs clearnet node breakdown is not available** — `torNodes` is always reported as `0`. All Knots nodes are counted under `clearnetNodes`.

## Tested on

Self-hosted instance with this patch running live: ~17,800 Knots nodes (19.6%), ~7,700 BIP110 nodes out of ~90,500 total.