### PR TITLE
refactor: standardize Mempool glass/Goggles category naming to 'spam'

### DIFF
--- a/backend/src/mempool.interfaces.ts
+++ b/backend/src/mempool.interfaces.ts
@@ -279,7 +279,7 @@ export const TransactionFlags = {
   cpfp_parent:                               0b00000001_00000000_00000000n,
   cpfp_child:                                0b00000010_00000000_00000000n,
   replacement:                               0b00000100_00000000_00000000n,
-  // data
+  // spam
   op_return:                        0b00000001_00000000_00000000_00000000n,
   fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
   inscription:                      0b00000100_00000000_00000000_00000000n,

--- a/frontend/src/app/docs/api-docs/api-docs.component.html
+++ b/frontend/src/app/docs/api-docs/api-docs.component.html
@@ -427,7 +427,7 @@
       </dl>
     </dd>
 
-    <dt>Data</dt>
+    <dt>Spam</dt>
     <dd>
       Different methods of embedding arbitrary data in a Bitcoin transaction.
       <dl>

--- a/frontend/src/app/shared/filters.utils.ts
+++ b/frontend/src/app/shared/filters.utils.ts
@@ -41,7 +41,7 @@ export const TransactionFlags = {
   cpfp_child:                                0b00000010_00000000_00000000n,
   replacement:                               0b00000100_00000000_00000000n,
   acceleration:                              0b00001000_00000000_00000000n,
-  // data
+  // spam
   op_return:                        0b00000001_00000000_00000000_00000000n,
   fake_pubkey:                      0b00000010_00000000_00000000_00000000n,
   inscription:                      0b00000100_00000000_00000000_00000000n,
@@ -99,7 +99,7 @@ export const TransactionFilters: { [key: string]: Filter } = {
     cpfp_child: { key: 'cpfp_child', label: 'Pays for parent', flag: TransactionFlags.cpfp_child, important: true, tooltip: true, txPage: false, },
     replacement: { key: 'replacement', label: 'Replacement', flag: TransactionFlags.replacement, important: true, tooltip: true, txPage: false, },
     acceleration: window?.['__env']?.ACCELERATOR ? { key: 'acceleration', label: $localize`:@@b484583f0ce10f3341ab36750d05271d9d22c9a1:Accelerated`, flag: TransactionFlags.acceleration, important: false } : undefined,
-    /* data */
+    /* spam */
     op_return: { key: 'op_return', label: 'OP_RETURN', flag: TransactionFlags.op_return, important: true, tooltip: true, txPage: true, },
     fake_pubkey: { key: 'fake_pubkey', label: 'Fake pubkey', flag: TransactionFlags.fake_pubkey, tooltip: true, txPage: true, },
     inscription: { key: 'inscription', label: $localize`:@@99264845cdffed75db1a32df6e66febbdf1d99f1:Inscription`, flag: TransactionFlags.inscription, important: true, tooltip: true, txPage: true, },
@@ -122,7 +122,7 @@ export const FilterGroups: { label: string, filters: Filter[]}[] = [
   { label: $localize`:@@885666551418fd59011ceb09d5c481095940193b:Features`, filters: ['rbf', 'no_rbf', 'v1', 'v2', 'v3', 'nonstandard'] },
   { label: $localize`Address Types`, filters: ['p2pk', 'p2ms', 'p2pkh', 'p2sh', 'p2wpkh', 'p2wsh', 'p2tr'] },
   { label: $localize`Behavior`, filters: ['cpfp_parent', 'cpfp_child', 'replacement', 'acceleration'] },
-  { label: $localize`Data`, filters: ['op_return', 'fake_pubkey', 'fake_scripthash', 'inscription', 'annex', 'opnet'] },
+  { label: $localize`Spam`, filters: ['op_return', 'fake_pubkey', 'fake_scripthash', 'inscription', 'annex', 'opnet'] },
   { label: $localize`Heuristics`, filters: ['coinjoin', 'consolidation', 'batch_payout'] },
   { label: $localize`Sighash Flags`, filters: ['sighash_all', 'sighash_none', 'sighash_single', 'sighash_default', 'sighash_acp'] },
 ].map(group => ({ label: group.label, filters: group.filters.map(filter => TransactionFilters[filter] || null).filter(f => f != null) }));


### PR DESCRIPTION
## Summary

This PR standardizes the naming of the arbitrary data embedding category across both Mempool Glass and Mempool Goggles.

The two components were using different identifiers for the same category: Mempool Glass uses `spam`, while parts of the Mempool Goggles implementation still referenced it as `data`. This inconsistency made the codebase harder to follow and maintain.

This change aligns Mempool Goggles with the existing Mempool Glass naming by consistently using `spam` throughout both implementations.

<img width="300" height="300" alt="imagen" src="https://github.com/user-attachments/assets/eefeb443-8ac3-408b-96ed-e85c5dc1bda0" /><img width="300" height="300" alt="imagen" src="https://github.com/user-attachments/assets/ec2171c4-eca2-455f-98e2-6e0b13cb46c4" />

## Changes

* Renamed all remaining `data` category references in Mempool Goggles to `spam`.
* Updated the affected mappings and related code paths to use the same identifier as Mempool Glass.
* No functional changes to the filters themselves; this is purely a naming consistency improvement.

## Result

Mempool Glass and Mempool Goggles now use the same category identifier (`spam`) for arbitrary data embedding filters, improving consistency across the project, making the codebase easier to maintain, and reducing the risk of future inconsistencies.