### PR TITLE
Widen blocks.header so larger block headers can be indexed

### DIFF
--- a/backend/src/api/database-migration.ts
+++ b/backend/src/api/database-migration.ts
@@ -7,7 +7,7 @@ import cpfpRepository from '../repositories/CpfpRepository';
 import { RowDataPacket } from 'mysql2';
 
 class DatabaseMigration {
-  private static currentVersion = 111;
+  private static currentVersion = 112;
   private queryTimeout = 3600_000;
   private statisticsAddedIndexed = false;
   private uniqueLogs: string[] = [];
@@ -1255,6 +1255,11 @@ class DatabaseMigration {
       await this.$executeQuery('ALTER TABLE `compact_cpfp_clusters` ADD template_algo TINYINT UNSIGNED NOT NULL DEFAULT 0');
       await this.updateToSchemaVersion(111);
     }
+
+    if (databaseSchemaVersion < 112 && isBitcoin === true) {
+      await this.$executeQuery('ALTER TABLE `blocks` MODIFY `header` varchar(512) NOT NULL');
+      await this.updateToSchemaVersion(112);
+    }
   }
 
   /**
@@ -1600,7 +1605,7 @@ class DatabaseMigration {
       ADD segwit_total_txs int unsigned NOT NULL,
       ADD segwit_total_size int unsigned NOT NULL,
       ADD segwit_total_weight int unsigned NOT NULL,
-      ADD header varchar(160) NOT NULL,
+      ADD header varchar(512) NOT NULL,
       ADD utxoset_change int NOT NULL,
       ADD utxoset_size int unsigned NULL,
       ADD total_input_amt bigint unsigned NULL


### PR DESCRIPTION
`blocks.header` is `varchar(160)`, which fits exactly an 80 byte header. A chain whose headers are larger cannot be indexed: every write fails with `Data too long for column 'header'`, and `$updateBlocks` retries the same block indefinitely.

Widens the column to 512 for both fresh installs and existing databases (schema version 112). Gated on `isBitcoin` like the neighboring migrations. `varchar` stores only the bytes used, so mainnet is unaffected.

Verified against MariaDB 10.5.21:

| | schema_version | blocks.header |
|---|---|---|
| before | 111 | `varchar(160)` |
| after, same db | 112 | `varchar(512)` |
| after, empty db | 112 | `varchar(512)` |

`npm run test:with-db` passes.
