### PR TITLE
chain-tips: Skip the canonical lookup for stale blocks above the tip

### DIFF
--- a/backend/src/api/chain-tips.ts
+++ b/backend/src/api/chain-tips.ts
@@ -17,7 +17,8 @@ export interface ChainTip {
 
 export interface StaleTip extends ChainTip {
   stale: BlockExtended;
-  canonical: BlockExtended;
+  // absent when the stale block sits above the active tip, where no canonical block exists
+  canonical?: BlockExtended;
 }
 
 export interface OrphanedBlock {
@@ -34,6 +35,7 @@ class ChainTips {
   private blockCache: { [hash: string]: OrphanedBlock } = {};
   private orphansByHeight: { [height: number]: OrphanedBlock[] } = {};
   private indexingOrphanedBlocks = false;
+  private activeTipHeight = 0;
   private indexingQueue: { blockhash?: string, block?: IEsploraApi.Block, tip: OrphanedBlock }[] = [];
 
   private staleTipsCacheSize = 50;
@@ -45,6 +47,7 @@ class ChainTips {
       this.chainTips = await bitcoinClient.getChainTips();
 
       const activeTipHeight = this.chainTips.find(tip => tip.status === 'active')?.height || (await bitcoinApi.$getBlockHeightTip());
+      this.activeTipHeight = activeTipHeight;
       let minIndexHeight = 0;
       const indexedBlockAmount = Math.min(config.MEMPOOL.INDEXING_BLOCKS_AMOUNT, activeTipHeight);
       if (indexedBlockAmount > 0) {
@@ -168,7 +171,11 @@ class ChainTips {
         }
 
         if (staleBlock && needToCache) {
-          const canonicalBlock = await blocks.$indexBlockByHeight(staleBlock.height);
+          // A valid-fork can reach above the active tip (more blocks, less work);
+          // there is no canonical block at those heights and getblockhash throws
+          const canonicalBlock = staleBlock.height <= this.activeTipHeight
+            ? await blocks.$indexBlockByHeight(staleBlock.height)
+            : undefined;
           this.staleTips[staleBlock.height] = {
             height: staleBlock.height,
             hash: staleBlock.id,


### PR DESCRIPTION
## What
`$indexOrphanedBlocks` no longer asks for the canonical block at a stale block's height when that height is above the active tip. `StaleTip.canonical` becomes optional.

## Why
A `valid-fork` can reach above the active tip when it has more blocks but less cumulative work; testnet's minimum-difficulty blocks make that routine. At those heights `getblockhash` throws, so the stale block is never cached and the error repeats on every loop, which is #15.

## How I tested
`tsc` on the backend reports no errors from this change (the only error in my checkout is the unbuilt `rust-gbt` native module, present before and after). The frontend's stale list already reads the field as `chainTip.canonical?.id || chainTip.height`, so a missing canonical block renders as the height alone. I have not reproduced the fork-above-tip state on my own node; its only stale branch above the tip is `invalid`, which this code skips.

## Risk and rollback
One conditional and one optional field. Revert the commit.

## Still unsure about
This code is unchanged from upstream mempool, so the same fix applies there; I can open it upstream as well if you prefer it land there first.
