### PR TITLE
fee-api: Scale the fee thresholds by the configured block weight

### DIFF
--- a/backend/src/api/fee-api.ts
+++ b/backend/src/api/fee-api.ts
@@ -90,11 +90,15 @@ class FeeApi {
 
   private optimizeMedianFee(pBlock: MempoolBlock, nextBlock: MempoolBlock | undefined, previousFee: number | undefined, minFee: number, minIncrement: number = this.minimumIncrement): number {
     const useFee = previousFee ? (pBlock.medianFee + previousFee) / 2 : pBlock.medianFee;
-    if (pBlock.blockVSize <= 500000 || pBlock.medianFee < minFee) {
+    // Thresholds follow the configured block size; at the 4,000,000 WU default
+    // they are the historical 500,000 and 950,000 vsize.
+    const blockVSize = config.MEMPOOL.BLOCK_WEIGHT_UNITS / 4;
+    const halfBlockVSize = blockVSize / 2;
+    if (pBlock.blockVSize <= halfBlockVSize || pBlock.medianFee < minFee) {
       return minFee;
     }
-    if (pBlock.blockVSize <= 950000 && !nextBlock) {
-      const multiplier = (pBlock.blockVSize - 500000) / 500000;
+    if (pBlock.blockVSize <= blockVSize * 0.95 && !nextBlock) {
+      const multiplier = (pBlock.blockVSize - halfBlockVSize) / halfBlockVSize;
       return Math.max(this.roundToNearest(useFee * multiplier, minIncrement), minFee);
     }
     return Math.max(this.roundUpToNearest(useFee, minIncrement), minFee);


### PR DESCRIPTION
## What
`optimizeMedianFee` derives its "block not full" and "nearly full" thresholds from `BLOCK_WEIGHT_UNITS` instead of the fixed 500,000 and 950,000 vsize. At the 4,000,000 WU default nothing changes.

## Why
On the Bitcoin Knots chain blocks are capped at 800,000 WU while RDTS is active, so an instance configured with `BLOCK_WEIGHT_UNITS: 800000` projects blocks of at most 200,000 vsize. The fixed 500,000 threshold then treats every projected block as empty and `fees/recommended` returns the minimum fee for all four tiers, while the first projected block's median fee sits at 5–6 sat/vB. Seen on my node today after switching the projection to 800k.

## How I tested
`tsc` clean. On a node with `BLOCK_WEIGHT_UNITS: 800000`, a 254,000-transaction mempool and a first projected block at 197,976 vsize with median 5.7 sat/vB: before, `{fastest: 1, halfHour: 1, hour: 1, economy: 1}`; after, the tiers follow the projected medians again.

## Risk and rollback
Two arithmetic lines. Revert the commit.

## Still unsure about
Whether you want `BLOCK_WEIGHT_UNITS: 800000` documented for Knots-chain deployments; mempool.guide currently projects 4,000,000 WU blocks, which shows the queue at a fifth of its length and estimates fees against blocks the chain cannot mine.
