### PR TITLE
Show a replay-protected badge in the transaction features row

### DIFF
--- a/contributors/melvincarvalho.txt
+++ b/contributors/melvincarvalho.txt
@@ -1,0 +1,3 @@
+I hereby accept the terms of the Contributor License Agreement in the CONTRIBUTING.md file of the mempool/mempool git repository as of November 17, 2023.
+
+Signed: melvincarvalho

--- a/frontend/src/app/bitcoin.utils.ts
+++ b/frontend/src/app/bitcoin.utils.ts
@@ -266,6 +266,7 @@ const featureActivation = {
     rbf: 399701,
     segwit: 477120,
     taproot: 709632,
+    unified: 961640,
   },
   testnet: {
     rbf: 720255,
@@ -276,6 +277,7 @@ const featureActivation = {
     rbf: 0,
     segwit: 0,
     taproot: 0,
+    unified: 150308,
   },
   signet: {
     rbf: 0,
@@ -284,7 +286,7 @@ const featureActivation = {
   },
 };
 
-export function isFeatureActive(network: string, height: number, feature: 'rbf' | 'segwit' | 'taproot'): boolean {
+export function isFeatureActive(network: string, height: number, feature: 'rbf' | 'segwit' | 'taproot' | 'unified'): boolean {
   const activationHeight = featureActivation[network || 'mainnet']?.[feature];
   if (activationHeight != null) {
     return height >= activationHeight;

--- a/frontend/src/app/components/tx-features/tx-features.component.html
+++ b/frontend/src/app/components/tx-features/tx-features.component.html
@@ -28,3 +28,9 @@
 <span *ngIf="isRbfTransaction; else rbfDisabled" class="badge bg-success" i18n-ngbTooltip="RBF tooltip" ngbTooltip="This transaction supports Replace-By-Fee (RBF) allowing fee bumping" placement="bottom" i18n="tx-features.tag.rbf|RBF">RBF</span>
 <ng-template #rbfDisabled><span class="badge bg-danger me-1" i18n-ngbTooltip="RBF disabled tooltip" ngbTooltip="This transaction does NOT support Replace-By-Fee (RBF) and cannot be fee bumped using this method" placement="bottom"><del i18n="tx-features.tag.rbf|RBF">RBF</del></span></ng-template>
 </ng-template>
+
+<ng-template [ngIf]="unifiedEnabled">
+<span *ngIf="replayProtection === 'all'" class="badge bg-success ms-1" ngbTooltip="Every input is signed with the unified opt-in sighash (SIGHASH_UNIFIED, 0x20). Nodes without the BLAKE2b hardfork cannot verify these signatures, so this transaction cannot be replayed onto the SHA256d chain." placement="bottom">Replay protected</span>
+<span *ngIf="replayProtection === 'partial'" class="badge bg-warning ms-1" ngbTooltip="Some inputs are signed with the unified opt-in sighash and some are not. The transaction as a whole cannot be replayed, but the legacy-signed inputs offer no protection on their own." placement="bottom">Replay protected (partial)</span>
+<span *ngIf="replayProtection === 'none'" class="badge bg-danger ms-1" ngbTooltip="No input is signed with the unified opt-in sighash. This transaction is valid on both chains and can be replayed onto the SHA256d chain by anyone." placement="bottom"><del>Replay protected</del></span>
+</ng-template>

--- a/frontend/src/app/components/tx-features/tx-features.component.ts
+++ b/frontend/src/app/components/tx-features/tx-features.component.ts
@@ -2,6 +2,7 @@ import { Component, ChangeDetectionStrategy, OnChanges, Input } from '@angular/c
 import { calcSegwitFeeGains, isFeatureActive } from '@app/bitcoin.utils';
 import { Transaction } from '@interfaces/electrs.interface';
 import { StateService } from '@app/services/state.service';
+import { processInputSignatures } from '@app/shared/transaction.utils';
 
 @Component({
   selector: 'app-tx-features',
@@ -22,6 +23,12 @@ export class TxFeaturesComponent implements OnChanges {
   };
   isRbfTransaction: boolean;
   isTaproot: boolean;
+  // 'all': every parsed signature opts in to SIGHASH_UNIFIED (0x20), so the
+  // transaction is invalid on any chain without the hardfork.
+  // 'partial': some inputs opt in, some do not. 'none': no input opts in.
+  // 'unknown': no signatures could be parsed (e.g. unsupported script types).
+  replayProtection: 'all' | 'partial' | 'none' | 'unknown' = 'unknown';
+  unifiedEnabled: boolean;
 
   segwitEnabled: boolean;
   rbfEnabled: boolean;
@@ -41,5 +48,23 @@ export class TxFeaturesComponent implements OnChanges {
     this.segwitGains = calcSegwitFeeGains(this.tx);
     this.isRbfTransaction = this.tx.vin.some((v) => v.sequence < 0xfffffffe);
     this.isTaproot = this.tx.vin.some((v) => v.prevout && v.prevout.scriptpubkey_type === 'v1_p2tr');
+    this.unifiedEnabled = !this.tx.vin[0]?.is_coinbase
+      && (!this.tx.status.confirmed || isFeatureActive(this.stateService.network, this.tx.status.block_height, 'unified'));
+    this.replayProtection = this.unifiedEnabled ? this.classifyReplayProtection() : 'unknown';
+  }
+
+  private classifyReplayProtection(): 'all' | 'partial' | 'none' | 'unknown' {
+    let optedIn = 0;
+    let legacy = 0;
+    for (const vin of this.tx.vin) {
+      let sigs;
+      try { sigs = processInputSignatures(vin); } catch { sigs = []; }
+      if (!sigs?.length) { continue; }
+      if (sigs.every(sig => (sig.sighash & 0x20) !== 0)) { optedIn++; } else { legacy++; }
+    }
+    if (!optedIn && !legacy) { return 'unknown'; }
+    if (!legacy) { return 'all'; }
+    if (!optedIn) { return 'none'; }
+    return 'partial';
   }
 }


### PR DESCRIPTION
Closes #17.

On the BLAKE2b chain the only thing that stops a transaction being replayed onto the SHA256d chain is a signature that opts in to `SIGHASH_UNIFIED` (0x20). The key icon on each input already decodes the sighash into a tooltip, but the **Features** row, where people look for SegWit / Taproot / RBF, said nothing about it. This adds a **Replay protected** badge there.

### Behaviour

| Inputs | Badge |
|---|---|
| every parsed signature carries the unified flag | green `Replay protected` |
| mixed | amber `Replay protected (partial)` |
| none opt in | red, struck through, same style as a missing feature |
| coinbase, confirmed before the hardfork height, or no parseable signature | no badge |

Tooltips explain what each state means in one sentence, so a reader who has never met the sighash learns it by hovering.

### Implementation

- `tx-features.component.ts`: classify the transaction with `processInputSignatures`, the same helper the input rows use, so the badge always agrees with the key tooltips. It tests the 0x20 bit on each signature's hash type byte.
- `bitcoin.utils.ts`: add `unified` to the `featureActivation` table (961640 mainnet, 150308 testnet4) so the badge is gated like segwit and taproot and does not appear on pre-fork history.
- `tx-features.component.html`: the three badge states.

34 lines, frontend only, no backend or API change.

### Tested

Against a Knots `v29.4.1.knots20260508` testnet4 node with electrs and this backend in electrum mode:

- a taproot key-path spend signed with hash type 0x21 (65-byte Schnorr signature) shows the green badge; the same raw transaction is rejected by a Bitcoin Core testnet4 node with `Invalid Schnorr signature hash type`
- a P2WPKH faucet payout signed with plain `SIGHASH_ALL` (71-byte DER signature ending 01), which relays and confirms on both chains, shows the struck-through badge
- coinbase transactions and pre-fork transactions show nothing

Also adds `contributors/melvincarvalho.txt` per CONTRIBUTING.md.
